### PR TITLE
Enable pip cache

### DIFF
--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           cache: ${{ inputs.package-manager }}
-          cache-dependency-path: '**/setup.py'
+          cache-dependency-path: '**/setup.py' # https://github.com/actions/setup-python/issues/502
         
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/setup.py'
         
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install .[docs]

--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -38,8 +38,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
-          cache: 'pip'
-          cache-dependency-path: '**/setup.py'
+          #cache: 'pip'
+        
       - name: Install dependencies
         run: |
           pip install .[docs]

--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
-          #cache: 'pip'
+          cache: 'pip'
         
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           python-version: ${{ inputs.python-version }}
           cache: 'pip'
+          cache-dependency-path: '**/setup.py'
       - name: Install dependencies
         run: |
           pip install .[docs]

--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -12,6 +12,10 @@ on:
           required: false
           type: string 
           default: ./doc
+        package-manager:
+          required: false 
+          type: string 
+          default: pip
        
     
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -38,7 +42,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ inputs.python-version }}
-          cache: 'pip'
+          cache: ${{ inputs.package-manager }}
           cache-dependency-path: '**/setup.py'
         
       - name: Install dependencies


### PR DESCRIPTION
In this PR, the caching of `pip` dependencies is implemented in the workflow [deploy-sphinx-docs-to-ghpages.yml](https://github.com/qibogang/workflows/compare/main...cache_pip#diff-86d45b733b6ad8772c2c9f9abe841be9d1e831000eaf182aa75cca6d3e2b6ea2)