### PR TITLE
add job `new-artifact`

### DIFF
--- a/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
+++ b/.github/workflows/deploy-sphinx-docs-to-ghpages.yml
@@ -14,6 +14,10 @@ on:
         dependency-path:
           required: true 
           type: string
+        trigger-label:
+          required: false
+          type: string
+          default: none
         path-doc:
           required: false
           type: string 
@@ -71,15 +75,71 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
+          name: documentation
           path: ${{ inputs.path-doc }}/build/html
-      
+  
+  # TODO: this job should have a own reusable workflow
+  new-artifact:
+    needs: [build]
+    if: ${{ [ inputs.trigger-label == 'latest' ] || [ inputs.trigger-label == 'stable' ] }} 
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: ls # TODO: remove this debugging line 
+    - uses: actions/download-artifact@v3
+      with:
+        name: documentation  
+    - run: | # TODO: remove this debugging line
+        ls 
+        pwd 
+    - name: generate the ${{inputs.trigger-label}} documentation 
+      run: |
+        label=${{inputs.trigger-label}}
+        mkdir new_docs
+        mv artifact.tar "${label}.tar" 
+        mv "${label}.tar" new_docs/
+        cd new_docs
+        ls # TODO: remove debugging line 
+        mkdir $label
+        tar -xf "${label}.tar" -C "${label}/" 
+        ls ../new_docs # TODO: remove this debugging line
+    - name: generate the remaning documentation
+      run: | 
+        label=${{inputs.trigger-label}} 
+        cd new_docs
+        if [[ ${label} == "latest" ]]; 
+          then 
+            missing_doc="stable"
+          else
+            missing_doc="latest"
+        fi
+        URL="https://qibogang.github.io/qibo/${missing_doc}/${missing_doc}"
+        mkdir "$missing_doc"
+        # Check if it is possible to connect to the website 
+        # Otherwise it copies the existing docs
+        if wget --spider "${URL}" 2>/dev/null; then 
+            wget "$URL"  
+        else
+            cp "${label}.tar" "${missing_doc}.tar"
+        fi   
+        tar -xf "${missing_doc}.tar" -C "${missing_doc}/"
+        echo "generate remaning doc" # TODO: remove this debugging line
+        ls # TODO: remove this debugging line
+        echo "let see in stable folder" # TODO: remove this debugging line
+        ls stable # TODO: remove this debugging line
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: new_docs/
+
+
   # Deployment job
   deploy:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url}}
     runs-on: ubuntu-latest
-    needs: build
+    needs: new-artifact
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
The job `new-artifact` builds an artifact that has both the `latest` and`stable` documentations.