### PR TITLE
Update upload-artifact version

### DIFF
--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -83,7 +83,7 @@ jobs:
           mkdir coverage
           mv coverage.xml coverage/
           mv htmlcov coverage/
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-from-self-hosted
           path: coverage/


### PR DESCRIPTION
As per title updates the version of upload artifacts to ``v4``. This is needed by qiboteam/qibo#1561.