### PR TITLE
update to checkout v6

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: qiboteam/workflows/actions/poetry/setup@v2
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/latest-stable.yml
+++ b/.github/workflows/latest-stable.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [build, check-label]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: generate the ${{inputs.trigger-label}} documentation
         run: |
           label=${{inputs.trigger-label}}

--- a/.github/workflows/selfhosted.yml
+++ b/.github/workflows/selfhosted.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Cleanup workspace manually
         run: |
           rm -rf _work/*
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ inputs.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: qiboteam/workflows/actions/poetry/setup@v2
         with:
           python-version: ${{ inputs.python-version }}
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ inputs.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: qiboteam/workflows/actions/poetry/setup@v2
         with:
           python-version: ${{ inputs.python-version }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -32,7 +32,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: qiboteam/workflows/actions/poetry/setup@v2
         with:
           python-version: ${{ inputs.python-version }}


### PR DESCRIPTION
Support for node 20 in github actions will end in June of this year: 
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

While checkout v4 still uses, but it is updated in v5. 
https://github.com/actions/checkout#checkout-v5

In this PR the workflows are update to use v6. 