### PR TITLE
update to codecov v6

### DIFF
--- a/actions/poetry/test/action.yaml
+++ b/actions/poetry/test/action.yaml
@@ -33,7 +33,7 @@ runs:
                                               # remove in next breaking change
     - name: Upload coverage to Codecov
       if: startsWith(runner.os, 'Linux')
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v6
       with:
         files: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
v6 also supports node 24. 

There are some breaking changes in v5 (`file` to `files` and `plugin` to `plugins`), but they had been deprecated already and updated in the workflow before so it should not break for us. 

https://github.com/codecov/codecov-action#v6-release

It is possible to do tokenless upload in case a token is not provided (so adding a condition), but I believe @scarrazza added tokens for both qibocal and qibolab, so for the time being we probably don't need it. 